### PR TITLE
[ADD] Database schema 세팅

### DIFF
--- a/db/migrations/20221114101536_create_users_table.sql
+++ b/db/migrations/20221114101536_create_users_table.sql
@@ -1,5 +1,0 @@
--- migrate:up
-
-
--- migrate:down
-

--- a/db/migrations/20221116041323_create_tables.sql
+++ b/db/migrations/20221116041323_create_tables.sql
@@ -1,0 +1,121 @@
+-- migrate:up
+CREATE TABLE users
+(
+    `id`          INT             NOT NULL    AUTO_INCREMENT, 
+    `name`        VARCHAR(45)     NOT NULL, 
+    `phone`       VARCHAR(45)     NOT NULL, 
+    `email`       VARCHAR(50)     NOT NULL, 
+    `password`    VARCHAR(200)    NOT NULL, 
+    `created_at`  TIMESTAMP       NOT NULL		DEFAULT CURRENT_TIMESTAMP, 
+    `updated_at`  TIMESTAMP       NULL		    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, 
+     PRIMARY KEY (id),
+     UNIQUE KEY `unique_users` (`email`)
+);
+
+CREATE TABLE products
+(
+    `id`             INT               NOT NULL    AUTO_INCREMENT, 
+    `category_id`    INT               NOT NULL, 
+    `brand_id`       INT               NOT NULL, 
+    `name`           VARCHAR(45)       NOT NULL, 
+    `information`    varchar(300)      NULL, 
+    `thumbnail`      VARCHAR(1000)     NOT NULL, 
+    `target_id`      INT               NOT NULL, 
+    `price`          DECIMAL(8, 2)     NOT NULL, 
+    `made_from`      VARCHAR(45)       NOT NULL, 
+    `expiry_date`    VARCHAR(45)       NOT NULL, 
+    `stock`          INT               NOT NULL, 
+    `discount_rate`  DECIMAL(8, 2)     NULL, 
+     PRIMARY KEY (id)
+);
+
+CREATE TABLE orders
+(
+    `id`             INT             NOT NULL    AUTO_INCREMENT, 
+    `user_id`        INT             NOT NULL, 
+    `price_total`    INT             NOT NULL, 
+    `order_comment`  VARCHAR(100)    NULL, 
+    `receiver`       VARCHAR(45)     NOT NULL, 
+    `address`        VARCHAR(45)     NOT NULL, 
+    `created_at`     TIMESTAMP       NOT NULL 	DEFAULT CURRENT_TIMESTAMP, 
+    `updated_at`     TIMESTAMP       NULL 		DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, 
+    `order_number`   INT             NOT NULL, 
+    `order_status`   VARCHAR(45)     NOT NULL, 
+     PRIMARY KEY (id)
+);
+
+CREATE TABLE carts
+(
+    `id`          INT               NOT NULL    AUTO_INCREMENT, 
+    `user_id`     INT               NOT NULL, 
+    `product_id`  INT               NOT NULL, 
+    `quantity`    INT               NOT NULL, 
+    `price`       DECIMAL(8, 2)     NOT NULL, 
+    `created_at`  TIMESTAMP         NOT NULL 		DEFAULT CURRENT_TIMESTAMP, 
+    `updated_at`  TIMESTAMP         NULL 		    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, 
+     PRIMARY KEY (id),
+     UNIQUE KEY `unique_carts` (`user_id`, `product_id`)
+);
+
+CREATE TABLE categories
+(
+    `id`    INT            NOT NULL    AUTO_INCREMENT, 
+    `name`  VARCHAR(45)    NULL, 
+     PRIMARY KEY (id)
+);
+
+CREATE TABLE reviews
+(
+    `id`          INT            NOT NULL    AUTO_INCREMENT, 
+    `user_id`     INT            NOT NULL, 
+    `product_id`  INT            NOT NULL, 
+    `comment`     VARCHAR(45)    NOT NULL, 
+    `star_point`  INT            NOT NULL, 
+    `created_at`  TIMESTAMP      NOT NULL 		DEFAULT CURRENT_TIMESTAMP, 
+    `updated_at`  TIMESTAMP      NULL 		    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, 
+     PRIMARY KEY (id)
+);
+
+CREATE TABLE likes
+(
+    `id`          INT    NOT NULL    AUTO_INCREMENT, 
+    `product_id`  INT    NOT NULL, 
+    `user_id`     INT    NOT NULL, 
+     PRIMARY KEY (id),
+     UNIQUE KEY `unique_likes` (`product_id`, `user_id`)
+);
+
+CREATE TABLE order_items
+(
+    `id`          INT    NOT NULL    AUTO_INCREMENT, 
+    `product_id`  INT    NOT NULL, 
+    `order_id`    INT    NOT NULL, 
+    `quantity`    INT    NOT NULL, 
+     PRIMARY KEY (id)
+);
+
+CREATE TABLE brands
+(
+    `id`    INT            NOT NULL    AUTO_INCREMENT, 
+    `name`  VARCHAR(45)    NOT NULL, 
+     PRIMARY KEY (id)
+);
+
+CREATE TABLE targets
+(
+    `id`    INT            NOT NULL    AUTO_INCREMENT, 
+    `name`  VARCHAR(45)    NOT NULL, 
+     PRIMARY KEY (id)
+);
+
+-- migrate:down
+DROP TABLE users;
+DROP TABLE products;
+DROP TABLE orders;
+DROP TABLE carts;
+DROP TABLE categories;
+DROP TABLE reviews;
+DROP TABLE likes;
+DROP TABLE order_items;
+DROP TABLE brands;
+DROP TABLE targets;

--- a/db/migrations/20221116042802_add_constraints_fk.sql
+++ b/db/migrations/20221116042802_add_constraints_fk.sql
@@ -1,0 +1,57 @@
+-- migrate:up
+-- order(주문)
+ALTER TABLE orders
+    ADD CONSTRAINT FK_order_user_id_users_id FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+-- carts(장바구니)
+ALTER TABLE carts
+    ADD CONSTRAINT FK_carts_user_id_users_id FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE carts
+    ADD CONSTRAINT FK_carts_product_id_products_id FOREIGN KEY (product_id)
+        REFERENCES products (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- categories
+ALTER TABLE products
+    ADD CONSTRAINT FK_products_category_id_products_id FOREIGN KEY (category_id)
+        REFERENCES categories (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- reviews
+ALTER TABLE reviews
+    ADD CONSTRAINT FK_reviews_user_id_users_id FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE reviews
+    ADD CONSTRAINT FK_reviews_product_id_products_id FOREIGN KEY (product_id)
+        REFERENCES products (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- likes
+ALTER TABLE likes
+    ADD CONSTRAINT FK_likes_user_id_users_id FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE likes
+    ADD CONSTRAINT FK_likes_product_id_products_id FOREIGN KEY (product_id)
+        REFERENCES products (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- order_items
+ALTER TABLE order_items
+    ADD CONSTRAINT FK_order_items_order_id_orders_id FOREIGN KEY (order_id)
+        REFERENCES orders (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE order_items
+    ADD CONSTRAINT FK_order_items_product_id_products_id FOREIGN KEY (product_id)
+        REFERENCES products (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- brands
+ALTER TABLE products
+    ADD CONSTRAINT FK_products_brand_id_products_id FOREIGN KEY (brand_id)
+        REFERENCES brands (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+-- targets
+ALTER TABLE products
+    ADD CONSTRAINT FK_products_target_id_products_id FOREIGN KEY (target_id)
+        REFERENCES targets (id) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- database schema 초기 세팅

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 기존에 만들었던 ERD를 기반으로 sql table을 만들었습니다. 
- 각각의 테이블은 dbmate를 이용하였습니다. 

![스크린샷 2022-11-16 오후 3 34 51](https://user-images.githubusercontent.com/64992490/202102723-5df609fc-8dab-4d59-a001-08c3f462245e.png)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 데이터베이스 폴더 관리(dbmate)
   - 이번에 구현한 것과 같이 각각의 테이블을 만드는 sql문을 하나의 폴더에 넣거나, 테이블별로 폴더를 하나하나 만들어 넣거나, 이렇게 두개의 방식으로 구성을 할 수 있음을 알게 되었습니다. 하나에 폴더에 table을 생성하는 sql구문을, 또 다른 폴더에는 foreign key를 만드는 constraint에 관한 내용들을 몰아서 넣었을때는 어떤 테이블이 만들어졌고 어떤 내용에 제한조건들이 걸려있는지 보기에 편했었습니다. 하지만 dbmate up을 했을때 중간에 에러가 난다면 요청한 migration이 끝나지 않고 중간에 멈춰버리는 것을 알게 되었습니다. 그렇게 되면 dbmate rollback도 되지 않았습니다(migration이 사실 시작해서 끝까지 작동해서 끝난 것이 아니기 때문에). 확실히 두개의 방법으로 두개 모두 사용해보니 장단점을 느낄수있었습니다.
- 데이터베이스 테이블 네이밍
   - 처음에 order라는 테이블명을 사용했을때 계속 오류가 나는 것을 확인했습니다. 복수형이 아니라 그런건지 orders를 사용했더니 에러없이 진행이 되었습니다. 그 이유는 아니였고 sql의 명령을 뜻하는 단어들을 테이블명으로 사용했을때 syntax error가 발생하는 것이였습니다.(int,creat,order 등)
- foreign key
   - 어떤 테이블에서 어떤 테이블을 참조하는지 명확히 판단해서 지정해줘야했습니다. brands, categories,targets의 fk를 지정해줄때 참조를 products를 해버려서 에러가 발생했었습니다. 

<br />

## :: 기타 질문 및 특이 사항
