### PR TITLE
ADD: JWT-refresh token 기능 추가 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@
     - 제품 전체 페이지
         - 필터,정렬, 페이지네이션을 적용하여 리스트 불러오는 api구현
     - 제품 상세 페이지
-    - API Document
+    - [API Document](https://documenter.getpostman.com/view/24101709/2s8YmUMzja)
+      
 - 이은영
-    - 로그인, 회원가입
-        - Bcrypt 암호화와 JsonWebToken 인증을 적용한 회원가입, 로그인 기능 API 구현
     - 찜하기 생성, 조회 및 삭제 API 구현
         - JsonWebToken을 통하여 얻은 user id로 제품 찜하기 Create, Read, Delete 구현
     - API Document

--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
-# [TEAM_HealthEat] WECODE 39기 1차 프로젝트
+# <p align="center">💊 HealthEat
 
-## 프로젝트 소개
+<br>
 
-- 제목 : 건강식품 판매 사이트 pilly를 모델링 한 프로젝트
+ ✏️ [프로젝트 중간 회고](https://amethyst-mahogany-d44.notion.site/1-5d3ba733dc5849fe917f193ce115af58)
+ 
+ ✏️ [프로젝트 협업 회고](https://amethyst-mahogany-d44.notion.site/1-f995ad91ada941b79e26eaf0d40e4272)
+ 
+ ✏️ [프로젝트 스프린트 회고](https://amethyst-mahogany-d44.notion.site/1-KPT-59a716399527468e9c0c91cdbb2bed11)
+ 
+ ✏️ [프로젝트 Code 회고](https://amethyst-mahogany-d44.notion.site/1-079e4f0bdc974a22811481fdd5761b9b)
+ 
+<br>
 
-- 선정이유
+## 📊 프로젝트 소개
+
+
+### 선정이유
   - 건강기능식품을 처음 접하고, 구매하고자하는 유저에게 친숙하게 다가가보자는 의견을 배경으로 제작하게 되었습니다.
-  - FE 측면 : 반응형 사이트, 케럿셀, 상품 내부 옵션별 이미지 삽입, 쿼리파라미터(페이지네이션, 오더링) 구현 목표
-  - BE 측면 : 로그인, 회원가입, 로그인한 회원의 찜하기 기능 및 상품 내부 옵션별 데이터 구성, 쿼리파라미터를 이용하여 하나의 라우터와 서비스를 통해 제품 조회관련 모든 기능 구현 목표
+  - `FE 측면` : 반응형 사이트, 케럿셀, 상품 내부 옵션별 이미지 삽입, 쿼리파라미터(페이지네이션, 오더링) 구현 목표
+  - `BE 측면` : 로그인, 회원가입, 로그인한 회원의 찜하기 기능 및 상품 내부 옵션별 데이터 구성, 쿼리파라미터를 이용하여 하나의 라우터와 서비스를 통해 제품 조회관련 모든 기능 구현 목표
 
 ### 개발 인원 및 기간
 
-- 팀명: 헬스잇(HealthEat)
 - 개발기간 : 2022년 11월 14일 ~ 2022년 11월 25일 (10일)
 - 개발인원 : 프론트엔드 3명, 백엔드 2명
-    - FE : 우석민, 이상윤, 이혜원
-    - BE : 이은영, 조상원
-    - [프론트엔드 github 링크](https://github.com/wecode-bootcamp-korea/39-1st-HealthEat-frontend)
-    - [백엔드 github 링크](https://github.com/wecode-bootcamp-korea/39-1st-HealthEat-backend)
+    - 💻 FE : 우석민, 이상윤, 이혜원
+    - 💻 BE : 이은영, 조상원
 
-## 적용 기술 및 구현 기능
+<br>
+
+## 🚀 적용 기술 및 담당 기능
 
 
 
@@ -29,22 +39,20 @@
 - **BE** : JavaScript, Node.js, Express, MySQL 8.0, Postman, Bcrypt, JWT
 - **협업 툴** : Notion, Slack, Figma, dbdiagram.io, Google Meeting, Google Drive
 
-### 구현 기능
+### 담당 기능
 
-- 조상원
-    - 로그인,회원가입
-        - Bcrypt 암호화와 JsonWebToken 인증을 적용한 회원가입, 로그인 기능 API 구현
-    - 제품 전체 페이지
-        - 필터,정렬, 페이지네이션을 적용하여 리스트 불러오는 api구현
-    - 제품 상세 페이지
-    - [API Document](https://documenter.getpostman.com/view/24101709/2s8YmUMzja)
+
+- 로그인,회원가입
+    - Bcrypt 암호화와 JsonWebToken 인증을 적용한 회원가입, 로그인 기능 API 구현
+- 제품 전체 페이지
+    - 사용자의 검색기능 향상을 위해 filtering과 sorting 기능 동시 구현
+    - 페이지 로딩 속도 향상을 위한 페이지네이션 기능 구현
+- 제품 상세 페이지
+- [API Document](https://documenter.getpostman.com/view/24101709/2s8YmUMzja)
       
-- 이은영
-    - 찜하기 생성, 조회 및 삭제 API 구현
-        - JsonWebToken을 통하여 얻은 user id로 제품 찜하기 Create, Read, Delete 구현
-    - API Document
+<br>
 
-### 상세내용
+## 🧷 상세내용
 
 - 로그인 기능 구현
 
@@ -55,12 +63,11 @@
 ![필리마켓_AdobeExpress 2](https://user-images.githubusercontent.com/107943132/205479523-8f42e79f-fb17-43f5-ad47-24ea0ed755b3.GIF)
 
 
-## API Document
-
-[HealthEat - API Document](https://documenter.getpostman.com/view/24101709/2s8YmUMzja)
 
 ## Reference
 
 - 이 프로젝트는 [pilly스토어 사이트](https://pilly.kr/store)를 참조하여 학습목적으로 만들었습니다.
 - 실무수준의 프로젝트이지만 학습용으로 만들었기 때문에 이 코드를 활용하여 이득을 취하거나 무단 배포할 경우 법적으로 문제될 수 있습니다.
 - 이 프로젝트에서 사용하고 있는 사진 모두 무료로 제공되는 소스를 이용하였습니다.
+
+HealthEat 프로젝트는 '피리 마켓', '필리'라는 서비스를 참고한 것일 뿐 프로젝트의 모든 기능은 실제 서비스 개발과정과 같이 처음부터 구현되었음을 밝힙니다.

--- a/app.js
+++ b/app.js
@@ -1,36 +1,22 @@
-require("dotenv").config();
 const express = require("express");
 const morgan = require("morgan");
 const cors = require("cors");
 
-const { sqlDataSource } = require("./src/models/data-source");
 const { router } = require("./src/routes");
 const { globalErrorHandler } = require("./src/util/errors");
-const app = express();
 
-app.use(express.json());
-app.use(cors());
-app.use(morgan("dev"));
+const createApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(cors());
+  app.use(morgan("dev"));
 
-app.use(router);
-app.use(globalErrorHandler);
+  app.use(router);
+  app.use(globalErrorHandler);
+
+  return app;
+};
 
 const PORT = 3000;
 
-sqlDataSource
-  .initialize()
-  .then(() => {
-    console.log("Data Source has been initialized!!!");
-  })
-  .catch((err) => {
-    console.log("Error during Data Source initialization", err);
-  });
-
-const start = async () => {
-  app.listen(PORT, () => console.log(`server is listening on ${PORT}`));
-};
-app.get("/ping", (req, res) => {
-  return res.status(200).json({ message: "pong" });
-});
-
-start();
+module.exports = { createApp };

--- a/db/migrations/20230302063112_add_refresh_token.sql
+++ b/db/migrations/20230302063112_add_refresh_token.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+ALTER TABLE users ADD refresh_token text NOT NULL;
+
+
+-- migrate:down
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,11 @@
       "dependencies": {
         "bcrypt": "^5.1.0",
         "cors": "^2.8.5",
-        "dbmate": "^1.0.3",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "jsonwebtoken": "^8.5.1",
         "mysql2": "^2.3.3",
-        "typeorm": "^0.3.10"
+        "typeorm": "^0.3.12"
       },
       "devDependencies": {
         "morgan": "^1.10.0"
@@ -471,14 +470,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/dbmate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dbmate/-/dbmate-1.0.3.tgz",
-      "integrity": "sha512-1IqUL8KLwZ7GIn2RgZFJZYCq/lxsopZucjlZaf6N5i9gWOvJcEViLeN0rNsRTNmx9YgxyYZw0C4aI3U3oo2EyA==",
-      "bin": {
-        "dbmate": "dist/cli.js"
       }
     },
     "node_modules/debug": {
@@ -1701,9 +1692,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1718,27 +1709,27 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.12.tgz",
+      "integrity": "sha512-sYSxBmCf1nJLLTcYtwqZ+lQIRtLPyUoO93rHTOKk9vJCyT4UfRtU7oRsJvfvKP3nnZTD1hzz2SEy2zwPEN6OyA==",
       "dependencies": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
         "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
         "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "yargs": "^17.6.2"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -1754,12 +1745,12 @@
       "peerDependencies": {
         "@google-cloud/spanner": "^5.18.0",
         "@sap/hana-client": "^2.12.25",
-        "better-sqlite3": "^7.1.2",
+        "better-sqlite3": "^7.1.2 || ^8.0.0",
         "hdb-pool": "^0.1.6",
         "ioredis": "^5.0.4",
         "mongodb": "^3.6.0",
         "mssql": "^7.3.0",
-        "mysql2": "^2.2.5",
+        "mysql2": "^2.2.5 || ^3.0.1",
         "oracledb": "^5.1.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
@@ -1824,6 +1815,14 @@
         }
       }
     },
+    "node_modules/typeorm/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/typeorm/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1838,6 +1837,49 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/typeorm/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typeorm/node_modules/mkdirp": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz",
+      "integrity": "sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typeorm/node_modules/ms": {
@@ -1867,9 +1909,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2314,11 +2356,6 @@
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
-    },
-    "dbmate": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dbmate/-/dbmate-1.0.3.tgz",
-      "integrity": "sha512-1IqUL8KLwZ7GIn2RgZFJZYCq/lxsopZucjlZaf6N5i9gWOvJcEViLeN0rNsRTNmx9YgxyYZw0C4aI3U3oo2EyA=="
     },
     "debug": {
       "version": "2.6.9",
@@ -3258,9 +3295,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -3272,29 +3309,37 @@
       }
     },
     "typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.12.tgz",
+      "integrity": "sha512-sYSxBmCf1nJLLTcYtwqZ+lQIRtLPyUoO93rHTOKk9vJCyT4UfRtU7oRsJvfvKP3nnZTD1hzz2SEy2zwPEN6OyA==",
       "requires": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
         "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
         "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "yargs": "^17.6.2"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3302,6 +3347,31 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "mkdirp": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.3.tgz",
+          "integrity": "sha512-sjAkg21peAG9HS+Dkx7hlG9Ztx7HLeKnvB3NQRcu/mltCVmvkF0pisbiTSfDVYTT86XEfZrTUosLdZLStquZUw=="
         },
         "ms": {
           "version": "2.1.2",
@@ -3326,9 +3396,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon app.js",
+    "start": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -25,7 +25,7 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^8.5.1",
     "mysql2": "^2.3.3",
-    "typeorm": "^0.3.10"
+    "typeorm": "^0.3.12"
   },
   "devDependencies": {
     "morgan": "^1.10.0"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,23 @@
+require("dotenv").config();
+const { sqlDataSource } = require("./src/models/data-source");
+const { createApp } = require("./app");
+
+const start = async () => {
+  const app = createApp();
+  const PORT = process.env.PORT;
+
+  sqlDataSource
+    .initialize()
+    .then(() => {
+      console.log("Data Source has been initialized!!!");
+    })
+    .catch((err) => {
+      console.log("Error during Data Source initialization", err);
+    });
+  app.listen(PORT, () => console.log(`server is listening on ${PORT}`));
+};
+// app.get("/ping", (req, res) => {
+//   return res.status(200).json({ message: "pong" });
+// });
+
+start();

--- a/src/controllers/likeController.js
+++ b/src/controllers/likeController.js
@@ -3,7 +3,7 @@ const { Errors } = require("../util/errors");
 const { catchAsync } = require("../util/errors");
 
 const createLike = catchAsync(async (req, res) => {
-  const userId = req.user.id;
+  const userId = req.id;
   const { productId } = req.body;
 
   if (!productId) {
@@ -15,7 +15,7 @@ const createLike = catchAsync(async (req, res) => {
 });
 
 const getLikeList = async (req, res) => {
-  const userId = req.user.id;
+  const userId = req.id;
 
   const [products, name] = await likeService.getLikeList(userId);
   res.status(200).json([products, name]);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -17,8 +17,8 @@ const signin = async (req, res) => {
   const { email, password } = req.body;
 
   try {
-    const accessToken = await userService.signin(email, password);
-    res.status(200).json({ accessToken });
+    const { access_token, refresh_token } = await userService.signin(email, password);
+    res.status(200).json({ access_token, refresh_token });
   } catch (error) {
     res.status(error.statusCode || 400).json({ message: error.message });
   }

--- a/src/models/userDao.js
+++ b/src/models/userDao.js
@@ -10,10 +10,28 @@ const createUser = async (name, phone, email, password) => {
         password) 
       VALUES (?, ?, ?, ?)
           `,
-      [ name, phone, email, password ]
+      [name, phone, email, password]
     );
   } catch (err) {
+    console.log(err);
     throw new Error("INVALID DATA INPUT");
+  }
+};
+
+const createRefreshToken = async (refresh_token, userId) => {
+  try {
+    await sqlDataSource.query(
+      `
+      UPDATE 
+        users 
+      SET 
+        refresh_token= ?
+      WHERE id = ? `,
+      [refresh_token, userId]
+    );
+  } catch (err) {
+    console.log(err);
+    throw new Error("error: refresh token");
   }
 };
 
@@ -31,7 +49,7 @@ const getUserByEmail = async (email) => {
         WHERE
           users.email = ?
         `,
-    [ email ]
+    [email]
   );
   return user;
 };
@@ -50,10 +68,10 @@ const getUserById = async (id) => {
         WHERE 
           users.id = ?
         `,
-    [ id ]
+    [id]
   );
-  
+
   return user;
 };
 
-module.exports = { getUserByEmail, createUser,getUserById };
+module.exports = { getUserByEmail, createUser, getUserById, createRefreshToken };

--- a/src/services/likeService.js
+++ b/src/services/likeService.js
@@ -1,26 +1,27 @@
 const likeDao = require("../models/likeDao");
 
-const createLike = async(productId, userId) => {
-    const [checkLikeList] = await likeDao.checkLikeList(productId, userId)
+const createLike = async (productId, userId) => {
+  const [checkLikeList] = await likeDao.checkLikeList(productId, userId);
+  console.log(checkLikeList);
 
-    if (!productId) {
-        const err = new Error("INVALID_PRODUCT_ID");
-        err.statusCode = 400;
-        throw err;
-    }
-    
-    if (checkLikeList) {
-        await likeDao.deleteLike(productId, userId)
-        return false
-    } else {
-        await likeDao.createLike(productId, userId)
-        return true
-    }
-}
+  if (!productId) {
+    const err = new Error("INVALID_PRODUCT_ID");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (checkLikeList) {
+    await likeDao.deleteLike(productId, userId);
+    return false;
+  } else {
+    await likeDao.createLike(productId, userId);
+    return true;
+  }
+};
 
 const getLikeList = async (userId) => {
-    const getLikeList = await likeDao.getLikeList(userId)
-    return getLikeList
-}
+  const getLikeList = await likeDao.getLikeList(userId);
+  return getLikeList;
+};
 
-module.exports = { createLike, getLikeList }
+module.exports = { createLike, getLikeList };

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -2,6 +2,7 @@ const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 
 const { validateEmail } = require("../util/validators");
+const { generateAccessToken, generateRefreshToken } = require("../util/token");
 const userDao = require("../models/userDao");
 
 const signup = async (name, phone, email, password) => {
@@ -23,16 +24,16 @@ const signin = async (email, password) => {
     throw new Error("INVALID_USER", 401);
   }
 
-  const jwtToken = jwt.sign({ id: user.id }, process.env.JWT_SECRET_KEY, {
-    expiresIn: "1d",
-  });
+  const accessToken = generateAccessToken(user.id);
+  const refreshToken = generateRefreshToken(user.id);
+  await userDao.createRefreshToken(refreshToken, user.id);
 
-  return jwtToken;
+  return { accessToken, refreshToken };
 };
 
 const getUserById = async (id) => {
-  const user = await userDao.getUserById(id)
-  return user
-}
+  const user = await userDao.getUserById(id);
+  return user;
+};
 
 module.exports = { signup, signin, getUserById };

--- a/src/util/auth.js
+++ b/src/util/auth.js
@@ -1,23 +1,46 @@
-const jwt = require('jsonwebtoken');
-const  userService  = require('../services/userService');
-
+const jwt = require("jsonwebtoken");
+const userService = require("../services/userService");
+const { Errors } = require("./errors");
+const { generateAccessToken } = require("./token");
 
 const loginRequired = async (req, res, next) => {
   const accessToken = req.headers.authorization;
+  const refreshToken = req.headers.refresh_token;
+
   if (!accessToken) {
-    const error = new Error('NEED_ACCESSTOKEN');
-    error.statusCode = 401;
-    throw error;
+    throw new Errors("NEED_ACCESSTOKEN", 401);
   }
-  const verifyToken = jwt.verify(accessToken, process.env.JWT_SECRET_KEY);
-    const user = await userService.getUserById(verifyToken.id);
-  if (!user) {
-    const error = new Error('INVALID_USER');
-    error.statusCode = 400;
-    throw error;
+
+  try {
+    const decodedAccessToken = jwt.verify(accessToken, process.env.JWT_SECRET_KEY);
+    req.id = decodedAccessToken.id;
+    next();
+  } catch (err) {
+    //catch를 사용해 accessToken의 에러여부를 진단
+    // accessToken이 만료된 상황 -> refresh 토큰이 있는지 파악, 있으면 verify를 통해 access token 재발행,
+    if (err.name === "TokenExpiredError") {
+      try {
+        const decodedRefreshToken = jwt.verify(refreshToken, process.env.JWT_SECRET_KEY);
+        if (Date.now() >= decodedRefreshToken.exp * 1000) {
+          throw new Errors("RE_LOGIN_REQUIRED", 401);
+        }
+        const user = await userService.getUserById(decodedRefreshToken.id);
+        const newAccessToken = generateAccessToken(user.id);
+        req.id = user.id;
+        // 새로 발급된 access token은 response의 headers에 담아서 보낸다.
+        res.set("Authorization", newAccessToken);
+        next();
+      } catch (err) {
+        throw new Errors("JWT_REFRESH_ERROR", 401);
+      }
+    }
+    //access token의 signature의 인증이 실패한 상황
+    else if (err.message === "invalid signature") {
+      throw new Errors("CHECK_ACCESS_TOKEN_SECRET_KEY");
+    } else {
+      throw new Errors("JWT_ACCESS_ERROR");
+    }
   }
-  req.user = user;
-  next();
 };
 
 module.exports = { loginRequired };

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -1,0 +1,17 @@
+const jwt = require("jsonwebtoken");
+
+const generateAccessToken = async (userId) => {
+  const accessToken = jwt.sign({ id: userId }, process.env.JWT_SECRET_KEY, {
+    expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
+  });
+  return accessToken;
+};
+
+const generateRefreshToken = async (userId) => {
+  const refreshToken = jwt.sign({ id: userId }, process.env.JWT_SECRET_KEY, {
+    expiresIn: process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME,
+  });
+  return refreshToken;
+};
+
+module.exports = { generateAccessToken, generateRefreshToken };


### PR DESCRIPTION
## :: 최근 작업 주제
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 기본 JWT방식의 인증을 강화하기 위해 Refresh Token의 기능을 추가

<br />

## :: 구현 사항 설명 

- access token으로만 인증방식을 구현한다면 탈취 문제에 있어 유효시간을 짧게할 수 밖에 없고 그렇게되면 자주 로그인을 해줘야되는 문제를 해결하기 위해 refresh token의 기능을 추가하였다. 서버는 로그인 성공시 access token과 refresh token 모두를 발급하고 refresh token을 서버에 저장한다. refresh token은 보다 긴 유효기간을 가지고있어서 유효기간이 보다 짧은 access token이 만료되었을 때 재발급 해주는 열쇠의 역할은 한다. (JWT는 인증을 위해 사용되기에 payload에 중요한 정보를 담아서는 안된다!)

- access token을 검증할 때 만료가 되어 에러를 throw해주던 방식에서 try/catch를 사용해서 만료되어 에러가 나더라도 사용자에게 추가적인 요청이 아닌 내부적으로 해결할 수 있게 바꿨다. 사용자가 보다 쉽게 사이트에 접근할 수 있게끔 발생할 수 있는 hurdle을 제거해줄 수 있었다.
<br />

## :: 성장 포인트 
- try/catch문을 사용하여 사용자가 웹사이트를 이용할 때 hurdle이 되는 사항들을 제거해주며 사용자의 입장에서 개발을 하려고 생각하게되었다.

<br />

